### PR TITLE
setTemplate creates invalid template record

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -862,8 +862,8 @@ final class SiteApplication extends CMSApplication
 	/**
 	 * Overrides the default template that would be used
 	 *
-	 * @param   string  $template     The template name
-	 * @param   mixed   $styleParams  The template style parameters
+	 * @param \stdClass|string $template    The template name or definition
+	 * @param mixed            $styleParams The template style parameters
 	 *
 	 * @return  void
 	 *
@@ -871,19 +871,45 @@ final class SiteApplication extends CMSApplication
 	 */
 	public function setTemplate($template, $styleParams = null)
 	{
-		if (is_dir(JPATH_THEMES . '/' . $template))
+		if (is_object($template))
+		{
+			$templateName        = empty($template->template)
+				? ''
+				: $template->template;
+			$templateInheritable = empty($template->inheritable)
+				? 0
+				: $template->inheritable;
+			$templateParent      = empty($template->parent)
+				? ''
+				: $template->parent;
+			$templateParams      = empty($template->params)
+				? $styleParams
+				: $template->params;
+		}
+		else
+		{
+			$templateName        = $template;
+			$templateInheritable = 0;
+			$templateParent      = '';
+			$templateParams      = $styleParams;
+		}
+		
+		if (is_dir(JPATH_THEMES . '/' . $templateName))
 		{
 			$this->template = new \stdClass;
-			$this->template->template = $template;
+			$this->template->template = $templateName;
 
-			if ($styleParams instanceof Registry)
+			if ($templateParams instanceof Registry)
 			{
-				$this->template->params = $styleParams;
+				$this->template->params = $templateParams;
 			}
 			else
 			{
-				$this->template->params = new Registry($styleParams);
+				$this->template->params = new Registry($templateParams);
 			}
+
+			$this->template->inheritable = $templateInheritable;
+			$this->template->parent      = $templateParent;
 
 			// Store the template and its params to the config
 			$this->set('theme', $this->template->template);


### PR DESCRIPTION

Pull Request for Issue #32709.

### Summary of Changes

SiteApplication creates a full record for the new template, including inheritable and parent properties.

### Testing Instructions

```
Factory::getApplication()->setTemplate('new_template');
```

### Actual result BEFORE applying this Pull Request

```
[17-Mar-2021 09:05:41 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:41 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 179
[17-Mar-2021 09:05:41 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Plugin\PluginHelper.php on line 61
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Plugin\PluginHelper.php on line 61
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Plugin\PluginHelper.php on line 61
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Error\Renderer\HtmlRenderer.php on line 76
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Document\Renderer\Html\MetasRenderer.php on line 130
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Document\Renderer\Html\MetasRenderer.php on line 130
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Document\Renderer\Html\MetasRenderer.php on line 134
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Document\Renderer\Html\MetasRenderer.php on line 130
[17-Mar-2021 09:05:42 UTC] PHP Notice:  Undefined property: stdClass::$parent in V:\dev\workspaces\products\src\j4\libraries\src\Application\SiteApplication.php on line 402
``

### Expected result AFTER applying this Pull Request

No PHP notices when setting a new template.


### Documentation Changes Required

